### PR TITLE
Make the Database handle multiple index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Kerollmops <renault.cle@gmail.com>"]
 [dependencies]
 bincode = "1.0"
 byteorder = "1.2"
-crossbeam = "0.6"
 fst = "0.3"
 hashbrown = { version = "0.1", features = ["serde"] }
 lazy_static = "1.1"
@@ -25,12 +24,16 @@ features = ["preserve_order"]
 rev = "0372ba6"
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
-rev = "306e201"
+git = "https://github.com/Kerollmops/rust-rocksdb.git"
+rev = "3144b67"
 
 [dependencies.group-by]
 git = "https://github.com/Kerollmops/group-by.git"
 rev = "f1f5d8f"
+
+[dependencies.chashmap]
+git = "https://gitlab.redox-os.org/redox-os/tfs.git"
+rev = "b3e7cae1"
 
 [features]
 default = ["simd"]

--- a/examples/create-database.rs
+++ b/examples/create-database.rs
@@ -50,7 +50,10 @@ fn index(
     stop_words: &HashSet<String>,
 ) -> Result<Database, Box<Error>>
 {
-    let database = Database::create(database_path, &schema)?;
+    let database = Database::create(database_path)?;
+    database.create_index("example-index", &schema)?;
+
+    println!("start indexing...");
 
     let mut rdr = csv::Reader::from_path(csv_data_path)?;
     let mut raw_record = csv::StringRecord::new();
@@ -91,7 +94,7 @@ fn index(
         println!("building update...");
         let update = update.build()?;
         println!("ingesting update...");
-        database.ingest_update_file(update)?;
+        database.update_index("example-index", update)?;
     }
 
     Ok(database)

--- a/examples/query-database.rs
+++ b/examples/query-database.rs
@@ -93,7 +93,8 @@ fn main() -> Result<(), Box<Error>> {
         if input.read_line(&mut buffer)? == 0 { break }
         let query = buffer.trim_end_matches('\n');
 
-        let view = database.view();
+        let view = database.open_index("example-index")?;
+        let view = view.unwrap();
         let schema = view.schema();
 
         let (elapsed, documents) = elapsed::measure_time(|| {

--- a/src/rank/query_builder.rs
+++ b/src/rank/query_builder.rs
@@ -37,30 +37,30 @@ fn split_whitespace_automatons(query: &str) -> Vec<DfaExt> {
 
 pub type FilterFunc<D> = fn(DocumentId, &DatabaseView<D>) -> bool;
 
-pub struct QueryBuilder<'a, D, FI>
+pub struct QueryBuilder<'a, 'h, D, FI>
 where D: Deref<Target=DB>
 {
-    view: &'a DatabaseView<D>,
+    view: &'a DatabaseView<'h, D>,
     criteria: Criteria<D>,
     filter: Option<FI>,
 }
 
-impl<'a, D> QueryBuilder<'a, D, FilterFunc<D>>
+impl<'a, 'h, D> QueryBuilder<'a, 'h, D, FilterFunc<D>>
 where D: Deref<Target=DB>
 {
-    pub fn new(view: &'a DatabaseView<D>) -> Result<Self, Box<Error>> {
+    pub fn new(view: &'a DatabaseView<'h, D>) -> Result<Self, Box<Error>> {
         QueryBuilder::with_criteria(view, Criteria::default())
     }
 }
 
-impl<'a, D, FI> QueryBuilder<'a, D, FI>
+impl<'a, 'h, D, FI> QueryBuilder<'a, 'h, D, FI>
 where D: Deref<Target=DB>,
 {
-    pub fn with_criteria(view: &'a DatabaseView<D>, criteria: Criteria<D>) -> Result<Self, Box<Error>> {
+    pub fn with_criteria(view: &'a DatabaseView<'h, D>, criteria: Criteria<D>) -> Result<Self, Box<Error>> {
         Ok(QueryBuilder { view, criteria, filter: None })
     }
 
-    pub fn with_filter<F>(self, function: F) -> QueryBuilder<'a, D, F>
+    pub fn with_filter<F>(self, function: F) -> QueryBuilder<'a, 'h, D, F>
     where F: Fn(DocumentId, &DatabaseView<D>) -> bool,
     {
         QueryBuilder {
@@ -70,7 +70,7 @@ where D: Deref<Target=DB>,
         }
     }
 
-    pub fn with_distinct<F, K>(self, function: F, size: usize) -> DistinctQueryBuilder<'a, D, FI, F>
+    pub fn with_distinct<F, K>(self, function: F, size: usize) -> DistinctQueryBuilder<'a, 'h, D, FI, F>
     where F: Fn(DocumentId, &DatabaseView<D>) -> Option<K>,
           K: Hash + Eq,
     {
@@ -123,7 +123,7 @@ where D: Deref<Target=DB>,
     }
 }
 
-impl<'a, D, FI> QueryBuilder<'a, D, FI>
+impl<'a, 'h, D, FI> QueryBuilder<'a, 'h, D, FI>
 where D: Deref<Target=DB>,
       FI: Fn(DocumentId, &DatabaseView<D>) -> bool,
 {
@@ -174,18 +174,18 @@ where D: Deref<Target=DB>,
     }
 }
 
-pub struct DistinctQueryBuilder<'a, D, FI, FD>
+pub struct DistinctQueryBuilder<'a, 'h, D, FI, FD>
 where D: Deref<Target=DB>
 {
-    inner: QueryBuilder<'a, D, FI>,
+    inner: QueryBuilder<'a, 'h, D, FI>,
     function: FD,
     size: usize,
 }
 
-impl<'a, D, FI, FD> DistinctQueryBuilder<'a, D, FI, FD>
+impl<'a, 'h, D, FI, FD> DistinctQueryBuilder<'a, 'h, D, FI, FD>
 where D: Deref<Target=DB>,
 {
-    pub fn with_filter<F>(self, function: F) -> DistinctQueryBuilder<'a, D, F, FD>
+    pub fn with_filter<F>(self, function: F) -> DistinctQueryBuilder<'a, 'h, D, F, FD>
     where F: Fn(DocumentId, &DatabaseView<D>) -> bool,
     {
         DistinctQueryBuilder {
@@ -196,7 +196,7 @@ where D: Deref<Target=DB>,
     }
 }
 
-impl<'a, D, FI, FD, K> DistinctQueryBuilder<'a, D, FI, FD>
+impl<'a, 'h, D, FI, FD, K> DistinctQueryBuilder<'a, 'h, D, FI, FD>
 where D: Deref<Target=DB>,
       FI: Fn(DocumentId, &DatabaseView<D>) -> bool,
       FD: Fn(DocumentId, &DatabaseView<D>) -> Option<K>,


### PR DESCRIPTION
It uses the power of the rocksdb column-families.

I use [a fork of RocksDB](https://github.com/Kerollmops/rust-rocksdb/tree/chashmap) that uses [a concurrent HashMap](https://gitlab.redox-os.org/redox-os/tfs/tree/f4520febc8e1f25e31ecff6ad850442afa2ef745/chashmap).
Tests of the this fork does not compile for the moment.