### PR TITLE
Introduce binary group by in the query builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rev = "306e201"
 
 [dependencies.group-by]
 git = "https://github.com/Kerollmops/group-by.git"
-rev = "f1f5d8f"
+rev = "5a113fe"
 
 [features]
 default = ["simd"]

--- a/src/rank/query_builder.rs
+++ b/src/rank/query_builder.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::hash::Hash;
 use std::rc::Rc;
 
-use group_by::GroupByMut;
+use group_by::BinaryGroupByMut;
 use hashbrown::HashMap;
 use fst::Streamer;
 use rocksdb::DB;
@@ -154,7 +154,7 @@ where D: Deref<Target=DB>,
 
                 group.sort_unstable_by(|a, b| criterion.evaluate(a, b, view));
 
-                for group in GroupByMut::new(group, |a, b| criterion.eq(a, b, view)) {
+                for group in BinaryGroupByMut::new(group, |a, b| criterion.eq(a, b, view)) {
                     documents_seen += group.len();
                     groups.push(group);
 
@@ -231,7 +231,7 @@ where D: Deref<Target=DB>,
 
                 group.sort_unstable_by(|a, b| criterion.evaluate(a, b, view));
 
-                for group in GroupByMut::new(group, |a, b| criterion.eq(a, b, view)) {
+                for group in BinaryGroupByMut::new(group, |a, b| criterion.eq(a, b, view)) {
                     // we must compute the real distinguished len of this sub-group
                     for document in group.iter() {
                         let filter_accepted = match &self.inner.filter {


### PR DESCRIPTION
Here is the before/after http performance test!

```
Running 10s test @ http://localhost:2230
  2 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    39.36ms   86.47ms 917.41ms   91.06%
    Req/Sec   471.69     51.44   606.00     76.50%
  9396 requests in 10.01s, 2.48MB read
Requests/sec:    939.06
Transfer/sec:    254.02KB
```

```
Running 10s test @ http://localhost:2230
  2 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    18.86ms   49.39ms 614.89ms   95.23%
    Req/Sec   620.41     59.53   790.00     65.00%
  12359 requests in 10.00s, 3.26MB read
Requests/sec:   1235.54
Transfer/sec:    334.22KB
```

