### PR TITLE
Remove the QueryBuilder boxed criteria default static restriction

### DIFF
--- a/src/rank/criterion/mod.rs
+++ b/src/rank/criterion/mod.rs
@@ -51,17 +51,17 @@ impl<T: Criterion + ?Sized> Criterion for Box<T> {
 }
 
 #[derive(Default)]
-pub struct CriteriaBuilder {
-    inner: Vec<Box<dyn Criterion>>
+pub struct CriteriaBuilder<'a> {
+    inner: Vec<Box<dyn Criterion + 'a>>
 }
 
-impl CriteriaBuilder
+impl<'a> CriteriaBuilder<'a>
 {
-    pub fn new() -> CriteriaBuilder {
+    pub fn new() -> CriteriaBuilder<'a> {
         CriteriaBuilder { inner: Vec::new() }
     }
 
-    pub fn with_capacity(capacity: usize) -> CriteriaBuilder {
+    pub fn with_capacity(capacity: usize) -> CriteriaBuilder<'a> {
         CriteriaBuilder { inner: Vec::with_capacity(capacity) }
     }
 
@@ -69,29 +69,29 @@ impl CriteriaBuilder
         self.inner.reserve(additional)
     }
 
-    pub fn add<C>(mut self, criterion: C) -> CriteriaBuilder
-    where C: 'static + Criterion,
+    pub fn add<C: 'a>(mut self, criterion: C) -> CriteriaBuilder<'a>
+    where C: Criterion,
     {
         self.push(criterion);
         self
     }
 
-    pub fn push<C>(&mut self, criterion: C)
-    where C: 'static + Criterion,
+    pub fn push<C: 'a>(&mut self, criterion: C)
+    where C: Criterion,
     {
         self.inner.push(Box::new(criterion));
     }
 
-    pub fn build(self) -> Criteria {
+    pub fn build(self) -> Criteria<'a> {
         Criteria { inner: self.inner }
     }
 }
 
-pub struct Criteria {
-    inner: Vec<Box<dyn Criterion>>,
+pub struct Criteria<'a> {
+    inner: Vec<Box<dyn Criterion + 'a>>,
 }
 
-impl Default for Criteria {
+impl<'a> Default for Criteria<'a> {
     fn default() -> Self {
         CriteriaBuilder::with_capacity(7)
             .add(SumOfTypos)
@@ -105,8 +105,8 @@ impl Default for Criteria {
     }
 }
 
-impl AsRef<[Box<dyn Criterion>]> for Criteria {
-    fn as_ref(&self) -> &[Box<dyn Criterion>] {
+impl<'a> AsRef<[Box<Criterion + 'a>]> for Criteria<'a> {
+    fn as_ref(&self) -> &[Box<dyn Criterion + 'a>] {
         &self.inner
     }
 }

--- a/src/rank/query_builder.rs
+++ b/src/rank/query_builder.rs
@@ -39,30 +39,30 @@ fn split_whitespace_automatons(query: &str) -> Vec<DfaExt> {
 
 pub type FilterFunc<D> = fn(DocumentId, &DatabaseView<D>) -> bool;
 
-pub struct QueryBuilder<'a, D, FI>
+pub struct QueryBuilder<'a, 'b, D, FI>
 where D: Deref<Target=DB>
 {
     view: &'a DatabaseView<D>,
-    criteria: Criteria,
+    criteria: Criteria<'b>,
     filter: Option<FI>,
 }
 
-impl<'a, D> QueryBuilder<'a, D, FilterFunc<D>>
+impl<'a, 'b, D> QueryBuilder<'a, 'b, D, FilterFunc<D>>
 where D: Deref<Target=DB>
 {
     pub fn new(view: &'a DatabaseView<D>) -> Result<Self, Box<Error>> {
         QueryBuilder::with_criteria(view, Criteria::default())
     }
 
-    pub fn with_criteria(view: &'a DatabaseView<D>, criteria: Criteria) -> Result<Self, Box<Error>> {
+    pub fn with_criteria(view: &'a DatabaseView<D>, criteria: Criteria<'b>) -> Result<Self, Box<Error>> {
         Ok(QueryBuilder { view, criteria, filter: None })
     }
 }
 
-impl<'a, D, FI> QueryBuilder<'a, D, FI>
+impl<'a, 'b, D, FI> QueryBuilder<'a, 'b, D, FI>
 where D: Deref<Target=DB>,
 {
-    pub fn with_filter<F>(self, function: F) -> QueryBuilder<'a, D, F>
+    pub fn with_filter<F>(self, function: F) -> QueryBuilder<'a, 'b, D, F>
     where F: Fn(DocumentId, &DatabaseView<D>) -> bool,
     {
         QueryBuilder {
@@ -72,7 +72,7 @@ where D: Deref<Target=DB>,
         }
     }
 
-    pub fn with_distinct<F, K>(self, function: F, size: usize) -> DistinctQueryBuilder<'a, D, FI, F>
+    pub fn with_distinct<F, K>(self, function: F, size: usize) -> DistinctQueryBuilder<'a, 'b, D, FI, F>
     where F: Fn(DocumentId, &DatabaseView<D>) -> Option<K>,
           K: Hash + Eq,
     {
@@ -131,7 +131,7 @@ where D: Deref<Target=DB>,
     }
 }
 
-impl<'a, D, FI> QueryBuilder<'a, D, FI>
+impl<'a, 'b, D, FI> QueryBuilder<'a, 'b, D, FI>
 where D: Deref<Target=DB>,
       FI: Fn(DocumentId, &DatabaseView<D>) -> bool,
 {
@@ -185,18 +185,18 @@ where D: Deref<Target=DB>,
     }
 }
 
-pub struct DistinctQueryBuilder<'a, D, FI, FD>
+pub struct DistinctQueryBuilder<'a, 'b, D, FI, FD>
 where D: Deref<Target=DB>
 {
-    inner: QueryBuilder<'a, D, FI>,
+    inner: QueryBuilder<'a, 'b, D, FI>,
     function: FD,
     size: usize,
 }
 
-impl<'a, D, FI, FD> DistinctQueryBuilder<'a, D, FI, FD>
+impl<'a, 'b, D, FI, FD> DistinctQueryBuilder<'a, 'b, D, FI, FD>
 where D: Deref<Target=DB>,
 {
-    pub fn with_filter<F>(self, function: F) -> DistinctQueryBuilder<'a, D, F, FD>
+    pub fn with_filter<F>(self, function: F) -> DistinctQueryBuilder<'a, 'b, D, F, FD>
     where F: Fn(DocumentId, &DatabaseView<D>) -> bool,
     {
         DistinctQueryBuilder {
@@ -207,7 +207,7 @@ where D: Deref<Target=DB>,
     }
 }
 
-impl<'a, D, FI, FD, K> DistinctQueryBuilder<'a, D, FI, FD>
+impl<'a, 'b, D, FI, FD, K> DistinctQueryBuilder<'a, 'b, D, FI, FD>
 where D: Deref<Target=DB>,
       FI: Fn(DocumentId, &DatabaseView<D>) -> bool,
       FD: Fn(DocumentId, &DatabaseView<D>) -> Option<K>,


### PR DESCRIPTION
Thanks to [this rust forum answer](https://users.rust-lang.org/t/box-lifetime-problem/9030/2?u=kero), I forget that `Box<Trait + 'static>` is the default.