### PR TITLE
Remove the DatabaseView dependencies from the QueryBuilder

### DIFF
--- a/examples/query-database.rs
+++ b/examples/query-database.rs
@@ -156,7 +156,7 @@ fn main() -> Result<(), Box<Error>> {
 
         let start = Instant::now();
 
-        let builder = view.query_builder().unwrap();
+        let builder = view.query_builder();
         let documents = builder.query(query, 0..opt.number_results);
 
         let number_of_documents = documents.len();

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -32,7 +32,6 @@ pub use self::schema::Schema;
 pub use self::index::Index;
 pub use self::number::{Number, ParseNumberError};
 
-
 pub type RankedMap = HashMap<(DocumentId, SchemaAttr), Number>;
 
 const DATA_INDEX:      &[u8] = b"data-index";
@@ -803,7 +802,7 @@ mod bench {
 
         bench.iter(|| {
             for q in &["a", "b", "c", "d", "e"] {
-                let documents = view.query_builder().unwrap().query(q, 0..20);
+                let documents = view.query_builder().query(q, 0..20);
                 test::black_box(|| documents);
             }
         });
@@ -851,7 +850,7 @@ mod bench {
 
         bench.iter(|| {
             for q in &["a", "b", "c", "d", "e"] {
-                let documents = view.query_builder().unwrap().query(q, 0..20);
+                let documents = view.query_builder().query(q, 0..20);
                 test::black_box(|| documents);
             }
         });
@@ -900,7 +899,7 @@ mod bench {
 
         bench.iter(|| {
             for q in &["a", "b", "c", "d", "e"] {
-                let documents = view.query_builder().unwrap().query(q, 0..20);
+                let documents = view.query_builder().query(q, 0..20);
                 test::black_box(|| documents);
             }
         });

--- a/src/database/view.rs
+++ b/src/database/view.rs
@@ -85,8 +85,8 @@ where D: Deref<Target=DB>
         Ok(())
     }
 
-    pub fn query_builder(&self) -> Result<QueryBuilder<D, FilterFunc<D>>, Box<Error>> {
-        QueryBuilder::new(self)
+    pub fn query_builder(&self) -> QueryBuilder<FilterFunc> {
+        QueryBuilder::new(self.index())
     }
 
     pub fn raw_field_by_document_id(


### PR DESCRIPTION
This is one of the first step toward a workspace based version of MeiliDB.